### PR TITLE
Wrong title for imgAltIsTooLong test

### DIFF
--- a/src/resources/tests.yml
+++ b/src/resources/tests.yml
@@ -2229,7 +2229,7 @@ imgAltIsTooLong:
   type: "custom"
   testability: 1
   title:
-    en: "Image Alt text is short"
+    en: "Image Alt text is too long"
     nl: "Altteksten voor een afbeelding zijn kort"
   description:
     en: "All \"alt\" attributes for <code>img</code> elements should be clear and concise. \"Alt\" attributes over 100 characters long should be reviewed to see if they are too long."


### PR DESCRIPTION
Lets integrate quailjs/quail#284.
